### PR TITLE
Babel config updates

### DIFF
--- a/config/webpack/webpack.factory.js
+++ b/config/webpack/webpack.factory.js
@@ -16,13 +16,6 @@ const CommonsChunkPlugin = require("webpack/lib/optimize/CommonsChunkPlugin");
 const Clean = require('clean-webpack-plugin');
 
 /**
- * Settings for the babel-loader.
- * @see https://github.com/babel/babel-loader
- * @see https://babeljs.io/docs/plugins/#presets
- */
-const babelLoader = 'babel-loader?presets[]=es2015&presets[]=stage-1';
-
-/**
  * Regex used to indicate the libraries. Excludes:
  * * node_modules - modules loaded through npm
  * * bower_component - modules loaded through bower
@@ -110,22 +103,26 @@ function loaders(opts) {
      * Compiles typescript files into ES6, then compiles ES6 to ES5 with Babel.
      * @see https://github.com/TypeStrong/ts-loader
      * @see https://github.com/babel/babel-loader
+     * Babel presets are managed in the package.json file.
+     * @see https://babeljs.io/docs/plugins/#presets
      */
     loaders.push({
       test: /\.tsx?$/,
       exclude: libraries,
-      loaders: [babelLoader, 'ts-loader']
+      loaders: ['babel', 'ts']
     });
   }
 
   /**
    * Compiles ES6 JS into ES5.
    * @see https://github.com/babel/babel-loader
+   * Babel presets are managed in the package.json file.
+   * @see https://babeljs.io/docs/plugins/#presets
    */
   loaders.push({
     test: /\.js$/,
     exclude: libraries,
-    loader: babelLoader
+    loader: ['babel']
   });
 
   /**

--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
   },
   "author": "Eric Neuhauser",
   "license": "MIT",
+  "babel": {
+    "presets": [
+      "es2015",
+      "stage-1"
+    ]
+  },
   "devDependencies": {
     "angular-mocks": "^1.4.7",
     "autoprefixer": "^6.1.0",


### PR DESCRIPTION
Bable present definitions moved to package.json and simplify the webpack babel-loader as a result.  